### PR TITLE
fix(table): add row count

### DIFF
--- a/src/NamedItemContainer.js
+++ b/src/NamedItemContainer.js
@@ -11,6 +11,19 @@
  */
 const StatusCodeError = require('./StatusCodeError.js');
 
+/**
+ * Returns the actual error, recursively descending through all error properties.
+ *
+ * @param {Error} e error caught
+ */
+function getActualError(e) {
+  let error = e;
+  while ('error' in error) {
+    error = error.error;
+  }
+  return error;
+}
+
 class NamedItemContaner {
   constructor(oneDrive) {
     this._oneDrive = oneDrive;
@@ -26,8 +39,8 @@ class NamedItemContaner {
         comment: v.comment,
       }));
     } catch (e) {
-      this.log.error(e);
-      throw new StatusCodeError(e.msg, 500);
+      this.log.error(getActualError(e));
+      throw new StatusCodeError(e.message, e.statusCode || 500);
     }
   }
 
@@ -39,8 +52,8 @@ class NamedItemContaner {
       if (e.statusCode === 404) {
         return null;
       }
-      this.log.error(e);
-      throw new StatusCodeError(e.msg, 500);
+      this.log.error(getActualError(e));
+      throw new StatusCodeError(e.message, e.statusCode || 500);
     }
   }
 
@@ -61,8 +74,8 @@ class NamedItemContaner {
         },
       });
     } catch (e) {
-      this.log.error(e);
-      throw new StatusCodeError(e.msg, 500);
+      this.log.error(getActualError(e));
+      throw new StatusCodeError(e.message, e.statusCode || 500);
     }
   }
 
@@ -74,8 +87,8 @@ class NamedItemContaner {
         method: 'DELETE',
       });
     } catch (e) {
-      this.log.error(e);
-      throw new StatusCodeError(e.msg, 500);
+      this.log.error(getActualError(e));
+      throw new StatusCodeError(e.message, e.statusCode || 500);
     }
   }
 }

--- a/src/OneDrive.d.ts
+++ b/src/OneDrive.d.ts
@@ -94,6 +94,12 @@ export declare interface Table {
    * @param values values to replace rows with
    */
   replaceRow(index: string, values: string): Promise<void>;
+
+  /**
+   * Get the number of rows in the table, not including the header row
+   * @returns number of rows
+   */
+  getRowCount(): Promise<number>;
 }
 
 /**

--- a/test/NamedItemOps.js
+++ b/test/NamedItemOps.js
@@ -12,11 +12,17 @@
 
 'use strict';
 
-const namedItemOps = (namedItems) => (command, method, body) => {
+const StatusCodeError = require('../src/StatusCodeError.js');
+
+const namedItemOps = (namedItems) => ({ command, method, body }) => {
   if (!command) {
     return { value: namedItems };
   }
   if (command === 'add') {
+    const namedItem = namedItems.find((i) => i.name === body.name);
+    if (namedItem) {
+      throw new StatusCodeError(`Named item already exists: ${namedItem.name}`, 400);
+    }
     const len = namedItems.push({
       name: body.name,
       value: body.reference,
@@ -26,7 +32,7 @@ const namedItemOps = (namedItems) => (command, method, body) => {
   }
   const index = namedItems.findIndex((i) => i.name === command);
   if (index === -1) {
-    throw new Error('not found');
+    throw new StatusCodeError(`Named item not found: ${command}`, 404);
   }
   const item = namedItems[index];
   if (method === 'DELETE') {

--- a/test/Worksheet.test.js
+++ b/test/Worksheet.test.js
@@ -16,6 +16,8 @@
 
 const assert = require('assert');
 const Worksheet = require('../src/Worksheet.js');
+
+const getClient = require('./getClient.js');
 const namedItemOps = require('./NamedItemOps.js');
 
 const sampleSheet = {
@@ -23,10 +25,12 @@ const sampleSheet = {
   namedItems: [
     { name: 'alice', value: '$A2', comment: 'none' },
   ],
-  ops: (component, command, method, body) => {
+  ops: ({
+    component, command, method, body,
+  }) => {
     switch (component) {
       case 'names':
-        return namedItemOps(sampleSheet.namedItems)(command, method, body);
+        return namedItemOps(sampleSheet.namedItems)({ command, method, body });
       default:
         return { values: sampleSheet.name };
     }
@@ -34,16 +38,7 @@ const sampleSheet = {
 };
 
 const oneDrive = {
-  getClient: async () => {
-    const f = async ({
-      uri, method, body,
-    }) => {
-      const [, , component, command] = uri.split('/');
-      return sampleSheet.ops(component, command, method, body);
-    };
-    f.get = (uri) => f({ method: 'GET', uri });
-    return f;
-  },
+  getClient: async () => getClient(sampleSheet.ops),
 };
 
 describe('Worksheet Tests', () => {

--- a/test/getClient.js
+++ b/test/getClient.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+'use strict';
+
+const querystring = require('querystring');
+
+function getClient(ops) {
+  const f = ({
+    method, uri, body,
+  }) => {
+    // eslint-disable-next-line prefer-const
+    let [, , component, command] = uri.split('/');
+    let query = [];
+    if (component) {
+      const index = component.indexOf('?');
+      if (index !== -1) {
+        query = querystring.parse(component.substring(index + 1));
+        component = component.substring(0, index);
+      }
+    }
+    return ops({
+      method, component, query, command, body,
+    });
+  };
+  f.get = (uri) => f({ method: 'GET', uri });
+  return f;
+}
+
+module.exports = getClient;


### PR DESCRIPTION
Adding a method to retrieve the row count of a table, which requires OData Query Parameters, to not get all values back as well.

While checking the responses on actual OneDrive API, I noticed that the commonly used catch clause:
```
    } catch (e) {
      this.log.error(e);
      throw new StatusCodeError(e.msg, 500);
    }
```
actually logs the complete response returned by `request-promise-native`, including ALL headers, e.g. `Authorization`. Moreover, in case of an expected failure (e.g. adding a named item that already exists), the `e` is already an `StatusCodeError` where the inner error property contains the actual problem. I therefore added some code to retrieve the actual error and not overwrite the status code (see `getActualError` and its usages). What do you think, @tripodsan ?