### PR TITLE
feat(table): add getColumn method and simplify row handling

### DIFF
--- a/src/NamedItemContainer.js
+++ b/src/NamedItemContainer.js
@@ -74,7 +74,11 @@ class NamedItemContaner {
         },
       });
     } catch (e) {
-      this.log.error(getActualError(e));
+      const actual = getActualError(e);
+      if (actual.code === 'ItemAlreadyExists') {
+        throw new StatusCodeError(e.message, 409);
+      }
+      this.log.error(actual);
       throw new StatusCodeError(e.message, e.statusCode || 500);
     }
   }
@@ -87,7 +91,11 @@ class NamedItemContaner {
         method: 'DELETE',
       });
     } catch (e) {
-      this.log.error(getActualError(e));
+      const actual = getActualError(e);
+      if (actual.code === 'ItemNotFound') {
+        throw new StatusCodeError(e.message, 404);
+      }
+      this.log.error(actual);
       throw new StatusCodeError(e.message, e.statusCode || 500);
     }
   }

--- a/src/Table.js
+++ b/src/Table.js
@@ -70,7 +70,7 @@ class Table {
     try {
       const client = await this._oneDrive.getClient();
       const result = await client.get(`${this.uri}/rows`);
-      return result.value.map((v) => v.values);
+      return result.value.map((v) => v.values[0]);
     } catch (e) {
       this.log.error(e);
       throw new StatusCodeError(e.msg, 500);
@@ -81,7 +81,7 @@ class Table {
     try {
       const client = await this._oneDrive.getClient();
       const result = await client.get(`${this.uri}/rows/itemAt(index=${index})`);
-      return result.values;
+      return result.values[0];
     } catch (e) {
       this.log.error(getActualError(e));
       throw new StatusCodeError(e.message, e.statusCode || 500);
@@ -135,6 +135,17 @@ class Table {
       const client = await this._oneDrive.getClient();
       const result = await client.get(`${this.uri}/dataBodyRange?$select=rowCount`);
       return result.rowCount;
+    } catch (e) {
+      this.log.error(getActualError(e));
+      throw new StatusCodeError(e.message, e.statusCode || 500);
+    }
+  }
+
+  async getColumn(name) {
+    try {
+      const client = await this._oneDrive.getClient();
+      const result = await client.get(`${this.uri}/columns('${name}')`);
+      return result.values;
     } catch (e) {
       this.log.error(getActualError(e));
       throw new StatusCodeError(e.message, e.statusCode || 500);

--- a/test/getClient.js
+++ b/test/getClient.js
@@ -12,24 +12,18 @@
 
 'use strict';
 
-const querystring = require('querystring');
-
 function getClient(ops) {
   const f = ({
     method, uri, body,
   }) => {
     // eslint-disable-next-line prefer-const
     let [, , component, command] = uri.split('/');
-    let query = [];
+    let name = null;
     if (component) {
-      const index = component.indexOf('?');
-      if (index !== -1) {
-        query = querystring.parse(component.substring(index + 1));
-        component = component.substring(0, index);
-      }
+      [, component, , name] = component.match(/([^?(]+)(\('([^)]+)'\))?(\?(.+))?/);
     }
     return ops({
-      method, component, query, command, body,
+      method, component, name, command, body,
     });
   };
   f.get = (uri) => f({ method: 'GET', uri });


### PR DESCRIPTION
Adds a `getColumn` method to the Excel `Table` class.

Also simplifies row handling: rows were returned as an array of an array of values, e.g.:
```
row: [ [ 'a', 'b', 'c' ] ]
```
now is returned as just an array of values.