### PR TITLE
fix(caching): ensure that token cache is invalidated after password change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2146,7 +2146,6 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
           "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -5016,6 +5015,12 @@
       "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
       "dev": true
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -5808,6 +5813,18 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.0.tgz",
+      "integrity": "sha512-FiW8t91Je5yG5MVT1r+go1Z9bX3rCYIEjenUYeZrEl2v8aTWdIX336itrmQaKUO8Ske5Z7RHR7OIzr/9p0Ujjg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      }
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -10077,6 +10094,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "junit-report-builder": "2.1.0",
     "lint-staged": "10.4.0",
     "mocha": "7.2.0",
+    "nock": "13.0.0",
     "nyc": "15.1.0",
     "semantic-release": "17.1.2"
   },

--- a/src/OneDrive.d.ts
+++ b/src/OneDrive.d.ts
@@ -11,6 +11,7 @@
  */
 import { EventEmitter } from 'events';
 import { Workbook } from './Workbook';
+import { TokenResponse } from 'adal-node';
 
 /**
  * Logger interface
@@ -23,8 +24,6 @@ export declare interface OneDriveOptions {
   clientSecret?: string;
   refreshToken?: string;
   log?: Logger;
-  accessToken?: string;
-  expiresOn?: number;
   tenant?: string;
   username?: string;
   password?: string;
@@ -102,18 +101,24 @@ export declare class OneDrive extends EventEmitter {
   authorityUrl: string;
 
   /**
+   * Adds entries to the token cache
+   * @param {TokenResponse[]} entries
+   */
+  loadTokenCache(entries: TokenResponse[]): Promise<void>;
+
+  /**
    * Performs a login using an interactive flow which prompts the user to open a browser window and
    * enter the authorization code.
    * @params {function} [onCode] - optional function that gets invoked after code was retrieved.
-   * @returns {Promise<void>}
+   * @returns {Promise<TokenResponse>}
    */
-  login(onCode: Function): Promise<any>;
+  login(onCode: Function): Promise<TokenResponse>;
 
-  getAccessToken(autoRefresh: boolean): Promise<string>;
+  getAccessToken(autoRefresh: boolean): Promise<TokenResponse>;
 
   createLoginUrl(): string;
 
-  acquireToken(redirectUri: string, code: string): Promise<void>;
+  acquireToken(redirectUri: string, code: string): Promise<TokenResponse>;
 
   getClient(): Promise<Request>;
 


### PR DESCRIPTION
fixes #57

BREAKING CHANGE: changed API and switched token cache to ADALs internal memory cache
                 - the 'tokens' event now contains the all entries of the memory cache
                 - 'accessToken' and 'expiresOn' removed from options
                 - new method: OneDrive.loadTokenCache() to populate the memory cache
                 - 'login()', 'getAccessToken()', 'acquireToken()' now return the entire TokenResponse
