### PR TITLE
fix: asking for values first should just request those

### DIFF
--- a/src/Range.d.ts
+++ b/src/Range.d.ts
@@ -46,4 +46,9 @@ export declare interface Range {
    * and the row values as value.
    */
   getRowsAsObjects(): Promise<Array<object>>;
+
+  /**
+   * Returns the values of the range.
+   */
+  getValues(): Promise<Array<object>>;
 }


### PR DESCRIPTION
Related to https://github.com/adobe/helix-data-embed/issues/194

Requests `values` only, not the complete range object.