### PR TITLE
Improve authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1024,7 +1024,8 @@
     "@types/node": {
       "version": "8.10.59",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
-      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1073,19 +1074,25 @@
       "dev": true
     },
     "adal-node": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/adal-node/-/adal-node-0.2.1.tgz",
-      "integrity": "sha512-C/oasZuTy0NIqh5wPWjG/09XaG+zS7elC8upf1ZVExt9lSRncme4Ejbx8CKYk+wsGgj609y84txtRAXQVvqApg==",
+      "version": "git+https://github.com/adobe-rnd/azure-activedirectory-library-for-nodejs.git#4bbf4a6acf7788b7a77c39cc95a5d47f525587b9",
+      "from": "git+https://github.com/adobe-rnd/azure-activedirectory-library-for-nodejs.git#adobe",
       "requires": {
-        "@types/node": "^8.0.47",
+        "@types/node": "^10.17.47",
         "async": "^2.6.3",
         "date-utils": "*",
-        "jws": "3.x.x",
-        "request": "^2.88.0",
-        "underscore": ">= 1.3.1",
-        "uuid": "^3.1.0",
-        "xmldom": ">= 0.1.x",
+        "jws": "^3.2.2",
+        "request": "^2.88.2",
+        "underscore": "^1.12.0",
+        "uuid": "^3.4.0",
+        "xmldom": "^0.4.0",
         "xpath.js": "~1.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.47.tgz",
+          "integrity": "sha512-YZ1mMAdUPouBZCdeugjV8y1tqqr28OyL8DYbH5ePCfe9zcXtvbh1wDBy7uzlHkXo3Qi07kpzXfvycvrkby/jXw=="
+        }
       }
     },
     "agent-base": {
@@ -11956,9 +11963,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ=="
     },
     "union-value": {
       "version": "1.0.1",
@@ -12270,9 +12277,9 @@
       "dev": true
     },
     "xmldom": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.2.1.tgz",
-      "integrity": "sha512-kXXiYvmblIgEemGeB75y97FyaZavx6SQhGppLw5TKWAD2Wd0KAly0g23eVLh17YcpxZpnFym1Qk/eaRjy1APPg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+      "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
     },
     "xpath.js": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/adobe/helix-onedrive-support#readme",
   "dependencies": {
-    "adal-node": "0.2.1",
+    "adal-node": "https://github.com/adobe-rnd/azure-activedirectory-library-for-nodejs.git#adobe",
     "request": "2.88.2",
     "request-promise-native": "1.0.9"
   },

--- a/src/OneDrive.js
+++ b/src/OneDrive.js
@@ -12,7 +12,7 @@
 
 // eslint-disable-next-line max-classes-per-file
 const EventEmitter = require('events');
-const util = require('util');
+const { promisify } = require('util');
 const { AuthenticationContext } = require('adal-node');
 const rp = require('request-promise-native');
 
@@ -70,9 +70,35 @@ class OneDrive extends EventEmitter {
       throw new Error('Missing clientId.');
     }
     this.authContext = new AuthenticationContext(this.authorityUrl);
+    [
+      'acquireUserCode',
+      'acquireToken',
+      'acquireTokenWithDeviceCode',
+      'acquireTokenWithRefreshToken',
+      'acquireTokenWithUsernamePassword',
+      'acquireTokenWithClientCredentials',
+    ].forEach((m) => {
+      this.authContext[m] = promisify(this.authContext[m].bind(this.authContext));
+    });
     const { cache } = this.authContext;
-    cache.find.promise = util.promisify(cache.find.bind(cache));
-    cache.add.promise = util.promisify(cache.add.bind(cache));
+    const originalAdd = cache.add;
+    cache.add = (entries, cb) => {
+      originalAdd.call(cache, entries, (...args) => {
+        // eslint-disable-next-line no-underscore-dangle
+        this.emit('tokens', cache._entries);
+        cb(...args);
+      });
+    };
+    const originalRemove = cache.remove;
+    cache.remove = (entries, cb) => {
+      originalRemove.call(cache, entries, (...args) => {
+        // eslint-disable-next-line no-underscore-dangle
+        this.emit('tokens', cache._entries);
+        cb(...args);
+      });
+    };
+    cache.add.promise = promisify(cache.add.bind(cache));
+    cache.find.promise = promisify(cache.find.bind(cache));
   }
 
   /**
@@ -110,68 +136,71 @@ class OneDrive extends EventEmitter {
    */
   async login(onCode) {
     const { log, authContext: context } = this;
-    const code = await new Promise((resolve, reject) => {
-      context.acquireUserCode(AZ_RESOURCE, this.clientId, 'en', (err, response) => {
-        if (err) {
-          log.error('Error while requesting user code', err);
-          reject(err);
-        } else {
-          resolve(response);
-        }
-      });
-    });
+
+    let code;
+    try {
+      code = await context.acquireUserCode(AZ_RESOURCE, this.clientId, 'en');
+    } catch (e) {
+      log.error('Error while requesting user code', e);
+      throw e;
+    }
 
     log.info(code.message);
     if (typeof onCode === 'function') {
       await onCode(code);
     }
 
-    return new Promise((resolve, reject) => {
-      context.acquireTokenWithDeviceCode(AZ_RESOURCE, this.clientId, code,
-        (err, response) => {
-          if (err) {
-            log.error('Error while requesting access token with device code', err);
-            reject(err);
-          } else {
-            // eslint-disable-next-line no-underscore-dangle
-            this.emit('tokens', context.cache._entries);
-            this.refreshToken = response.refreshToken;
-            resolve(response);
-          }
-        });
-    });
+    try {
+      const response = await context.acquireTokenWithDeviceCode(AZ_RESOURCE, this.clientId, code);
+      this.refreshToken = response.refreshToken;
+      return response;
+    } catch (e) {
+      log.error('Error while requesting access token with device code', e);
+      throw e;
+    }
   }
 
   /**
    */
   async getAccessToken() {
     const { log, authContext: context } = this;
-    return new Promise((resolve, reject) => {
-      const callback = (err, response) => {
-        if (err) {
-          log.error('Error while refreshing access token', err);
-          reject(err);
-        } else {
-          log.debug('Token acquired.');
-          // eslint-disable-next-line no-underscore-dangle
-          this.emit('tokens', context.cache._entries);
-          resolve(response);
-        }
-      };
+    // check if cached token is still valid
+    try {
+      const response = await context.acquireToken(AZ_RESOURCE, this.username, this.clientId);
+      if (response) {
+        // todo: check validity
+        return response;
+      }
+    } catch (e) {
+      log.warn(`Unable to acquire token from cache: ${e}`);
+    }
+
+    try {
       if (this.refreshToken) {
         log.debug('acquire token with refresh token.');
-        context.acquireTokenWithRefreshToken(this.refreshToken, this.clientId,
-          this.clientSecret, AZ_RESOURCE, callback);
+        const resp = await context.acquireTokenWithRefreshToken(
+          this.refreshToken, this.clientId, this.clientSecret, AZ_RESOURCE,
+        );
+        return await this.augmentAndCacheResponse(resp);
       } else if (this.username && this.password) {
         log.debug('acquire token with ROPC.');
-        context.acquireTokenWithUsernamePassword(AZ_RESOURCE, this.username, this.password,
-          this.clientId, callback);
-      } else {
+        return await context.acquireTokenWithUsernamePassword(
+          AZ_RESOURCE, this.username, this.password, this.clientId,
+        );
+      } else if (this.clientSecret) {
         log.debug('acquire token with client credentials.');
-        context.acquireTokenWithClientCredentials(AZ_RESOURCE, this.clientId, this.clientSecret,
-          callback);
+        return await context.acquireTokenWithClientCredentials(
+          AZ_RESOURCE, this.clientId, this.clientSecret,
+        );
+      } else {
+        const err = new StatusCodeError('No valid authentication credentials supplied.');
+        err.statusCode = 401;
+        throw err;
       }
-    });
+    } catch (e) {
+      log.error(`Error while refreshing access token ${e}`);
+      throw e;
+    }
   }
 
   /**
@@ -180,44 +209,38 @@ class OneDrive extends EventEmitter {
     return `${this.authorityUrl}/oauth2/authorize?response_type=code&scope=/.default&client_id=${this.clientId}&redirect_uri=${redirectUri}&state=${state}&resource=${AZ_RESOURCE}`;
   }
 
+  async augmentAndCacheResponse(response) {
+    // somehow adal doesn't add the clientId and authority to response
+    // eslint-disable-next-line no-underscore-dangle
+    if (!response._clientId) {
+      // eslint-disable-next-line no-underscore-dangle
+      response._clientId = this.clientId;
+      // eslint-disable-next-line no-underscore-dangle
+      response._authority = this.authorityUrl;
+    }
+    const found = await this.authContext.cache.find.promise({
+      refreshToken: response.refreshToken,
+    });
+    if (found.length) {
+      await this.authContext.cache.remove.promise(found);
+    }
+    await this.authContext.cache.add.promise([response]);
+    return response;
+  }
+
   /**
    */
   async acquireToken(redirectUri, code) {
     const { log, authContext: context } = this;
-    return new Promise((resolve, reject) => {
-      context.acquireTokenWithAuthorizationCode(
-        code,
-        redirectUri,
-        AZ_RESOURCE,
-        this.clientId,
-        this.clientSecret,
-        async (err, response) => {
-          if (err) {
-            log.error('Error while getting token with authorization code.', err);
-            reject(err);
-          } else {
-            // somehow adal doesn't add the clientId and authority to the this
-            // eslint-disable-next-line no-underscore-dangle
-            if (!response._clientId) {
-              // eslint-disable-next-line no-underscore-dangle
-              response._clientId = this.clientId;
-              // eslint-disable-next-line no-underscore-dangle
-              response._authority = this.authorityUrl;
-            }
-            const { cache } = context;
-            const found = await cache.find.promise({
-              refreshToken: response.refreshToken,
-            });
-            if (!found.length) {
-              await cache.add.promise([response]);
-            }
-            // eslint-disable-next-line no-underscore-dangle
-            this.emit('tokens', context.cache._entries);
-            resolve(response);
-          }
-        },
+    try {
+      const resp = await context.acquireTokenWithAuthorizationCode(
+        code, redirectUri, AZ_RESOURCE, this.clientId, this.clientSecret,
       );
-    });
+      return await this.augmentAndCacheResponse(resp);
+    } catch (e) {
+      log.error('Error while getting token with authorization code.', e);
+      throw e;
+    }
   }
 
   /**

--- a/src/OneDrive.js
+++ b/src/OneDrive.js
@@ -151,9 +151,7 @@ class OneDrive extends EventEmitter {
     }
 
     try {
-      const response = await context.acquireTokenWithDeviceCode(AZ_RESOURCE, this.clientId, code);
-      this.refreshToken = response.refreshToken;
-      return response;
+      return await context.acquireTokenWithDeviceCode(AZ_RESOURCE, this.clientId, code);
     } catch (e) {
       log.error('Error while requesting access token with device code', e);
       throw e;

--- a/src/OneDrive.js
+++ b/src/OneDrive.js
@@ -164,13 +164,8 @@ class OneDrive extends EventEmitter {
    */
   async getAccessToken() {
     const { log, authContext: context } = this;
-    // check if cached token is still valid
     try {
-      const response = await context.acquireToken(AZ_RESOURCE, this.username, this.clientId);
-      if (response) {
-        // todo: check validity
-        return response;
-      }
+      return await context.acquireToken(AZ_RESOURCE, this.username, this.clientId);
     } catch (e) {
       log.warn(`Unable to acquire token from cache: ${e}`);
     }


### PR DESCRIPTION
- promisify the adal api
- try to acquire token from cache before authenticating
- emit token even when cache is updated

this should also fix the refresh workarounds in `1d` cli. 