### PR TITLE
fix: not finding a cached entry should not log a warning

### DIFF
--- a/src/OneDrive.js
+++ b/src/OneDrive.js
@@ -168,6 +168,8 @@ class OneDrive extends EventEmitter {
     } catch (e) {
       if (e.message !== 'Entry not found in cache.') {
         log.warn(`Unable to acquire token from cache: ${e}`);
+      } else {
+        log.debug(`Unable to acquire token from cache: ${e}`);
       }
     }
 

--- a/src/OneDrive.js
+++ b/src/OneDrive.js
@@ -166,7 +166,9 @@ class OneDrive extends EventEmitter {
     try {
       return await context.acquireToken(AZ_RESOURCE, this.username, this.clientId);
     } catch (e) {
-      log.warn(`Unable to acquire token from cache: ${e}`);
+      if (e.message !== 'Entry not found in cache.') {
+        log.warn(`Unable to acquire token from cache: ${e}`);
+      }
     }
 
     try {


### PR DESCRIPTION
fix #119 

for the record: this message is thrown in https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/blob/023fb2e3913e522091368c58d473b0042e6d0c74/lib/token-request.js#L526