### PR TITLE
fix: return lastModifiedDateTime from fuzzyGetDriveItem

### DIFF
--- a/src/OneDrive.js
+++ b/src/OneDrive.js
@@ -378,7 +378,7 @@ class OneDrive extends EventEmitter {
 
     const query = {
       $top: 999,
-      $select: 'name,parentReference,file,id,size,webUrl',
+      $select: 'name,parentReference,file,id,size,webUrl,lastModifiedDateTime',
     };
     let fileList = [];
     do {


### PR DESCRIPTION
required for returning `Last-Modified` in word2md