### PR TITLE
feat: add initTenantFromMountPoint()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-onedrive-support",
-  "version": "8.0.11",
+  "version": "8.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-onedrive-support",
-      "version": "8.0.11",
+      "version": "8.0.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-fetch": "3.1.1",

--- a/src/OneDriveAuth.d.ts
+++ b/src/OneDriveAuth.d.ts
@@ -39,6 +39,14 @@ export declare interface OneDriveAuthOptions {
 }
 
 /**
+ * Helix config mount point
+ */
+declare interface MountPoint {
+  url: string;
+  tenantId?: string;
+}
+
+/**
  * Helper class that facilitates authentication for one drive.
  */
 export declare class OneDriveAuth {
@@ -92,7 +100,22 @@ export declare class OneDriveAuth {
    */
   authenticate(silentOnly: boolean): Promise<AuthenticationResult>;
 
+  /**
+   * Disposes allocated resources.
+   */
   dispose() : Promise<void>;
 
-  initTenantFromUrl(sharingUrl: string|URL): Promise<void>;
+  /**
+   * Initializes the tenant from the url by requesting the required information from microsoft.
+   * @param {string|URL} sharingUrl
+   * @returns {string} the tenant id
+   */
+  initTenantFromUrl(sharingUrl: string|URL): Promise<string>;
+
+  /**
+   * Initializes the tenant either with the `tenantId` of the mount point or via the share url.
+   * @param {MountPoint} mp
+   * @returns {string} the tenant id
+   */
+  initTenantFromMountPoint(mp: MountPoint): Promise<string>;
 }

--- a/src/OneDriveAuth.js
+++ b/src/OneDriveAuth.js
@@ -151,7 +151,7 @@ export class OneDriveAuth {
 
   async initTenantFromUrl(sharingUrl) {
     if (this.tenant) {
-      return;
+      return this.tenant;
     }
     const { log } = this;
     const tenantHost = OneDriveAuth.getTenantHostFromUrl(sharingUrl);
@@ -166,6 +166,20 @@ export class OneDriveAuth {
       }
     }
     log.info(`using tenant ${this.tenant} for ${tenantHost} from ${sharingUrl}`);
+    return this.tenant;
+  }
+
+  async initTenantFromMountPoint(mp) {
+    const { log } = this;
+    if (this.tenant) {
+      return this.tenant;
+    }
+    if (mp.tenantId) {
+      this.tenant = mp.tenantId;
+      log.info(`using tenant ${this.tenant} from fstab.`);
+      return this.tenant;
+    }
+    return this.initTenantFromUrl(mp.url);
   }
 
   /**

--- a/test/onedrive-auth.test.js
+++ b/test/onedrive-auth.test.js
@@ -107,6 +107,18 @@ describe('OneDriveAuth Tests', () => {
     });
   });
 
+  it('uses the tenant from a mountpoint', async () => {
+    const od = new OneDriveAuth({
+      clientId: 'foobar',
+      refreshToken: 'dummy',
+      localAuthCache: true,
+    });
+    await od.initTenantFromMountPoint({
+      tenantId: 'c0452eed-9384-4001-b1b1-71b3d5cf28ad',
+    });
+    assert.deepStrictEqual(od.tenant, 'c0452eed-9384-4001-b1b1-71b3d5cf28ad');
+  });
+
   it('resolves the tenant from a share link and caches it', async () => {
     nock(AZ_AUTHORITY_HOST_URL)
       .get('/onedrive.onmicrosoft.com/.well-known/openid-configuration')
@@ -121,7 +133,9 @@ describe('OneDriveAuth Tests', () => {
       localAuthCache: true,
       tenantCache,
     });
-    await od1.initTenantFromUrl('https://onedrive.com/a/b/c/d2');
+    await od1.initTenantFromMountPoint({
+      url: 'https://onedrive.com/a/b/c/d2',
+    });
 
     const od2 = new OneDriveAuth({
       clientId: 'foobar',
@@ -173,6 +187,11 @@ describe('OneDriveAuth Tests', () => {
     await od1.initTenantFromUrl('https://onedrive.com/a/b/c/d2');
     delete od1.tenant;
     await od1.initTenantFromUrl('https://onedrive.com/a/b/c/d2');
+
+    // this should not fetch it again
+    await od1.initTenantFromMountPoint({
+      url: 'https://onedrive.com/a/b/c/d2',
+    });
   });
 
   it('sets the access token an extract the tenant', async () => {


### PR DESCRIPTION
adds:

```ts

  /**
   * Initializes the tenant either with the `tenantId` of the mount point or via the share url.
   * @param {MountPoint} mp
   * @returns {string} the tenant id
   */
  initTenantFromMountPoint(mp: MountPoint): Promise<string>;
```