### PR TITLE
fix: add proper table in mock's addTable

### DIFF
--- a/test/Workbook.test.js
+++ b/test/Workbook.test.js
@@ -84,7 +84,7 @@ describe('Workbook Tests', () => {
     assert.strictEqual(row[0], 'Helix');
   });
   it('Add table with a specific name that is also the generated one', async () => {
-    const table = await book.addTable('sheet!A1:B4', true, 'Table2');
+    const table = await book.addTable('sheet!A1:B4', false, 'Table2');
     assert.strictEqual(table.name, 'Table2');
   });
   it('Add table with an existing name', async () => {

--- a/test/Workbook.test.js
+++ b/test/Workbook.test.js
@@ -18,6 +18,9 @@ import exampleBook from './fixtures/book.js';
 const TEST_SHARE_LINK = 'https://adobe.sharepoint.com/:x:/r/sites/cg-helix/Shared%20Documents/data-embed-unit-tests/example-data.xlsx';
 
 describe('Workbook Tests', () => {
+  /**
+   * @type {import('../src/index.js').Workbook}
+   */
   let book;
   let sampleBook;
   let oneDrive;
@@ -69,19 +72,23 @@ describe('Workbook Tests', () => {
     assert.deepStrictEqual(values, ['table']);
   });
   it('Add table with a generated name', async () => {
-    const table = await book.addTable('Sheet1!A1:C1', true);
+    const table = await book.addTable('sheet!A1:B4', true);
     assert.strictEqual(table.name, 'Table2');
   });
   it('Add table with a specific name', async () => {
-    const table = await book.addTable('Sheet1!A1:C1', true, 'index_table');
+    const table = await book.addTable('sheet!A1:B4', true, 'index_table');
     assert.strictEqual(table.name, 'index_table');
+    const headerNames = await table.getHeaderNames();
+    assert.strictEqual(headerNames[0], 'project');
+    const row = await table.getRow(0);
+    assert.strictEqual(row[0], 'Helix');
   });
   it('Add table with a specific name that is also the generated one', async () => {
-    const table = await book.addTable('Sheet1!A1:C1', true, 'Table2');
+    const table = await book.addTable('sheet!A1:B4', true, 'Table2');
     assert.strictEqual(table.name, 'Table2');
   });
   it('Add table with an existing name', async () => {
-    await assert.rejects(async () => book.addTable('Sheet1!A1:C1', true, 'table'), /Table name already exists/);
+    await assert.rejects(async () => book.addTable('sheet!A1:B4', true, 'table'), /Table name already exists/);
   });
   it('Get named items', async () => {
     const values = await book.getNamedItems();

--- a/test/Worksheet.test.js
+++ b/test/Worksheet.test.js
@@ -16,6 +16,9 @@ import { OneDriveMock, StatusCodeError } from '../src/index.js';
 import exampleBook from './fixtures/book.js';
 
 describe('Worksheet Tests', () => {
+  /**
+   * @type {import('../src/index.js').Worksheet}
+   */
   let sheet;
   let oneDrive;
   let book;
@@ -66,24 +69,24 @@ describe('Worksheet Tests', () => {
     assert.deepStrictEqual(values, ['table']);
   });
   it('Add table with a generated name', async () => {
-    const table = await sheet.addTable('A1:C1', true);
+    const table = await sheet.addTable('A1:B4', true);
     assert.strictEqual(table.name, 'Table2');
   });
   it('Add table with a specific name', async () => {
-    const table = await sheet.addTable('A1:C1', true, 'index_table');
+    const table = await sheet.addTable('A1:B4', true, 'index_table');
     assert.strictEqual(table.name, 'index_table');
   });
   it('Add table with a specific name that is also the generated one', async () => {
-    const table = await sheet.addTable('A1:C1', true, 'Table2');
+    const table = await sheet.addTable('A1:B4', true, 'Table2');
     assert.strictEqual(table.name, 'Table2');
   });
   it('Add table with an existing name', async () => {
-    await assert.rejects(async () => sheet.addTable('A1:C1', true, 'table'), /Table name already exists/);
+    await assert.rejects(async () => sheet.addTable('A1:B4', true, 'table'), /Table name already exists/);
   });
   it('Get used range address', async () => {
     const range = sheet.usedRange();
     const address = await range.getAddress();
-    assert.strictEqual(address, 'Sheet1!A1:B4');
+    assert.strictEqual(address, 'sheet!A1:B4');
   });
   it('Get used range address local', async () => {
     const range = sheet.usedRange();

--- a/test/fixtures/book.js
+++ b/test/fixtures/book.js
@@ -42,7 +42,7 @@ export default {
     tables,
     namedItems,
     usedRange: {
-      address: 'Sheet1!A1:B4',
+      address: 'sheet!A1:B4',
       addressLocal: 'A1:B4',
       values: [
         ['project', '  c r e a t e d  '],


### PR DESCRIPTION
`OneDriveMock` should create a proper "table" structure when a table is added