### PR TITLE
feat: introduce acquireMethod

### DIFF
--- a/src/OneDriveAuth.d.ts
+++ b/src/OneDriveAuth.d.ts
@@ -19,7 +19,7 @@ export declare interface OneDriveAuthOptions {
   scopes?: string[];
   onCode?: Function;
   localAuthCache?:boolean;
-  acquireMethods: string[];
+  acquireMethod?: string;
 
   /**
    * use cache plugin instead for default (global) token cache.

--- a/src/OneDriveAuth.d.ts
+++ b/src/OneDriveAuth.d.ts
@@ -19,6 +19,7 @@ export declare interface OneDriveAuthOptions {
   scopes?: string[];
   onCode?: Function;
   localAuthCache?:boolean;
+  acquireMethods: string[];
 
   /**
    * use cache plugin instead for default (global) token cache.

--- a/src/OneDriveAuth.js
+++ b/src/OneDriveAuth.js
@@ -84,6 +84,9 @@ export class OneDriveAuth {
     if (this.acquireMethod === ACQUIRE_METHODS.BY_DEVICE_CODE && !this.onCode) {
       throw new Error(`Authontication method ${ACQUIRE_METHODS.BY_DEVICE_CODE} requires 'onCode' parameter`);
     }
+    if (!this.acquireMethod && this.onCode) {
+      this.acquireMethod = ACQUIRE_METHODS.BY_DEVICE_CODE;
+    }
 
     if (!opts.noTenantCache && !process.env.HELIX_ONEDRIVE_NO_TENANT_CACHE) {
       /** @type {Map<string, string>} */

--- a/test/onedrive-auth.test.js
+++ b/test/onedrive-auth.test.js
@@ -13,7 +13,7 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import { UnsecuredJWT } from 'jose';
-import { OneDriveAuth } from '../src/OneDriveAuth.js';
+import { OneDriveAuth, ACQUIRE_METHODS } from '../src/OneDriveAuth.js';
 import { MemCachePlugin } from '../src/cache/MemCachePlugin.js';
 import { Nock } from './utils.js';
 
@@ -81,6 +81,7 @@ describe('OneDriveAuth Tests', () => {
       clientSecret: 'test-client-secret',
       resource: 'test-resource',
       tenant: 'common',
+      acquireMethods: [ACQUIRE_METHODS.byClientCredential],
     });
     const resp = await od.authenticate();
     delete resp.expiresOn;
@@ -154,6 +155,7 @@ describe('OneDriveAuth Tests', () => {
       clientSecret: 'test-client-secret',
       resource: 'test-resource',
       tenant: 'common',
+      acquireMethods: [ACQUIRE_METHODS.byClientCredential],
     });
     await assert.rejects(
       od.authenticate(false),

--- a/test/onedrive-auth.test.js
+++ b/test/onedrive-auth.test.js
@@ -157,7 +157,6 @@ describe('OneDriveAuth Tests', () => {
       onCode: async (code) => {
         assert.strictEqual(code.userCode, 'DTSWBVY27');
       },
-      acquireMethod: ACQUIRE_METHODS.BY_DEVICE_CODE,
     });
     await od.authenticate();
     assert.strictEqual(await od.isAuthenticated(), true);
@@ -252,7 +251,7 @@ describe('OneDriveAuth Tests', () => {
       }),
     });
     await assert.rejects(
-      async () => od3.authenticate(false),
+      async () => od3.authenticate(),
       Error('Unable to acquire token silently and no other acquire method supplied'),
     );
   });


### PR DESCRIPTION
The methods allowed to acquire new tokens should be explicit, to avoid falling back to an invalid token when the cached tokens expire.