### PR TITLE
fix: provide username and location in error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@adobe/helix-onedrive-support",
-  "version": "9.1.32",
+  "version": "10.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-onedrive-support",
-      "version": "9.1.32",
+      "version": "10.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.0.10",
-        "@adobe/helix-shared-tokencache": "1.0.0",
+        "@adobe/helix-shared-tokencache": "1.1.0",
         "@aws-sdk/client-s3": "3.321.1",
         "@azure/msal-node": "1.17.1",
         "jose": "4.14.3"
@@ -71,9 +71,9 @@
       }
     },
     "node_modules/@adobe/helix-shared-tokencache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-tokencache/-/helix-shared-tokencache-1.0.0.tgz",
-      "integrity": "sha512-OjSt/CqEqUv0Z/LVvvwY/W44nkt9gWaNNY0qsgLxVzLWd3c7TXqef+c/9UFjJvtj4fPYG6gUL0n7rSK3N8bCjg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-tokencache/-/helix-shared-tokencache-1.1.0.tgz",
+      "integrity": "sha512-dq766nKDFNlumhgJCWwMYNxHdIsTRcpnZIdKHRMgPTnjexT27hPULgBhyYhvCxxIVgqa2+xWLFjK7AxyGPJ97Q==",
       "dependencies": {
         "@adobe/fetch": "^4.0.10",
         "@aws-sdk/client-s3": "3.321.1"
@@ -12911,9 +12911,9 @@
       }
     },
     "@adobe/helix-shared-tokencache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-tokencache/-/helix-shared-tokencache-1.0.0.tgz",
-      "integrity": "sha512-OjSt/CqEqUv0Z/LVvvwY/W44nkt9gWaNNY0qsgLxVzLWd3c7TXqef+c/9UFjJvtj4fPYG6gUL0n7rSK3N8bCjg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-shared-tokencache/-/helix-shared-tokencache-1.1.0.tgz",
+      "integrity": "sha512-dq766nKDFNlumhgJCWwMYNxHdIsTRcpnZIdKHRMgPTnjexT27hPULgBhyYhvCxxIVgqa2+xWLFjK7AxyGPJ97Q==",
       "requires": {
         "@adobe/fetch": "^4.0.10",
         "@aws-sdk/client-s3": "3.321.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/adobe/helix-onedrive-support#readme",
   "dependencies": {
     "@adobe/fetch": "4.0.10",
-    "@adobe/helix-shared-tokencache": "1.0.0",
+    "@adobe/helix-shared-tokencache": "1.1.0",
     "@aws-sdk/client-s3": "3.321.1",
     "@azure/msal-node": "1.17.1",
     "jose": "4.14.3"

--- a/test/onedrive-auth.test.js
+++ b/test/onedrive-auth.test.js
@@ -225,7 +225,7 @@ describe('OneDriveAuth Tests', () => {
     nock.discovery();
     nock.unauthenticated();
     nock.openid();
-    nock.unauthenticated();
+    nock.revoked();
 
     const od2 = new OneDriveAuth({
       clientId: '83ab2922-5f11-4e4d-96f3-d1e0ff152856',

--- a/test/utils.js
+++ b/test/utils.js
@@ -102,5 +102,20 @@ export function Nock() {
       error_uri: 'https://login.microsoftonline.com/error?code=7000215',
     });
 
+  nocker.revoked = () => nocker('https://login.microsoftonline.com')
+    .post('/common/oauth2/v2.0/token')
+    .reply(400, {
+      error: 'invalid_grant',
+      error_description: 'AADSTS50173: The provided grant has expired due to it being revoked, a fresh auth token is needed. The user might have changed or reset their password.',
+      error_codes: [
+        50173,
+      ],
+      timestamp: '2022-11-15 14:21:12Z',
+      trace_id: '0360e583-c633-4ec7-a26d-691caf445c00',
+      correlation_id: 'a498e2d2-2c57-41b3-a833-e361099aa522',
+      error_uri: 'https://login.microsoftonline.com/error?code=50173',
+      suberror: 'badtoken',
+    });
+
   return nocker;
 }


### PR DESCRIPTION
Logged message will no longer include stack, and the message will look as follows:
```
Error while reacquiring token from cache.
Username: <username>
Auth-Location: <location in content-bus>
Message: <error message from onedrive>
```