### PR TITLE
fix: cachePlugin might be undefined

### DIFF
--- a/src/OneDriveAuth.js
+++ b/src/OneDriveAuth.js
@@ -134,7 +134,7 @@ export class OneDriveAuth {
     if (!this._app) {
       const { log, cachePlugin } = this;
 
-      const metadata = await cachePlugin.getPluginMetadata();
+      const metadata = await cachePlugin?.getPluginMetadata();
       if (metadata?.useClientCredentials) {
         this.pluginUseClientCredentials = true;
       }
@@ -302,7 +302,7 @@ export class OneDriveAuth {
     const { log } = this;
     const msg = `Error while reacquiring token from cache${forced ? ' (forced)' : ''}.`;
 
-    log.warn(`${msg}\nUsername: ${account.username}\nAuth-Location: ${this.cachePlugin.location}\nMessage: ${e.message}`);
+    log.warn(`${msg}\nUsername: ${account.username}\nAuth-Location: ${this.cachePlugin?.location}\nMessage: ${e.message}`);
   }
 
   /**

--- a/test/OneDriveAuth.test.js
+++ b/test/OneDriveAuth.test.js
@@ -42,13 +42,29 @@ describe('OneDriveAuth Tests', () => {
     assert.ok(auth);
   });
 
-  it('can be constructed with accesToken without clientId.', async () => {
+  it('can be constructed with accessToken without clientId.', async () => {
     const auth = new OneDriveAuth({
       accessToken: 'Bearer dummy',
     });
     assert.ok(auth);
     const accessToken = await auth.authenticate();
     assert.strictEqual(accessToken.accessToken, 'Bearer dummy');
+  });
+
+  it('can be constructed without cache plugin', async () => {
+    const savedValue = process.env.HELIX_ONEDRIVE_LOCAL_AUTH_CACHE;
+    try {
+      delete process.env.HELIX_ONEDRIVE_LOCAL_AUTH_CACHE;
+      const auth = new OneDriveAuth({
+        accessToken: 'Bearer dummy',
+      });
+      assert.ok(auth);
+      const accessToken = await auth.authenticate();
+      assert.strictEqual(accessToken.accessToken, 'Bearer dummy');
+      assert.strictEqual(auth.cachePlugin, undefined);
+    } finally {
+      process.env.HELIX_ONEDRIVE_LOCAL_AUTH_CACHE = savedValue;
+    }
   });
 
   it('can be disposed.', async () => {


### PR DESCRIPTION
unfortunately, no test covers this case because all tests set `process.env.HELIX_ONEDRIVE_LOCAL_AUTH_CACHE` which creates a fallback `cachePlugin`