### PR TITLE
feat: introduce `OneDrive.create(opts)`

### DIFF
--- a/src/OneDrive.d.ts
+++ b/src/OneDrive.d.ts
@@ -118,6 +118,12 @@ export declare class OneDrive extends EventEmitter {
   static driveItemFromURL(url: URL): DriveItem;
 
   /**
+   * Creates a new OneDrive helper using a static method. Facilitates creating a
+   * sinon stub to change the instance type returned.
+   */
+  static create(opts: OneDriveOptions): OneDrive;
+
+  /**
    * Creates a new OneDrive helper.
    * @param {OneDriveOptions} opts Options.
    */

--- a/src/OneDrive.js
+++ b/src/OneDrive.js
@@ -84,6 +84,10 @@ export class OneDrive {
     };
   }
 
+  static create(opts) {
+    return new OneDrive(opts);
+  }
+
   /**
    * @param {OneDriveOptions} opts Options
    */

--- a/test/onedrive.test.js
+++ b/test/onedrive.test.js
@@ -51,7 +51,12 @@ describe('OneDrive Tests', () => {
   });
 
   it('can be constructed.', async () => {
-    const drive = new OneDrive({
+    let drive = new OneDrive({
+      auth: DEFAULT_AUTH(),
+    });
+    assert.ok(drive);
+
+    drive = OneDrive.create({
       auth: DEFAULT_AUTH(),
     });
     assert.ok(drive);


### PR DESCRIPTION
... which can be more easily overridden with `sinon`